### PR TITLE
:books: :lipstick: Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Will start the program and connect as soon as the Yubikey is inserted (and not a
 
 ### Autostart via systemd
 
-* Copy yubi-oath-vpn binary to $HOMR/Apps/yubi-oath-vpn, make sure it's executable
+* Copy yubi-oath-vpn binary to $HOME/Apps/yubi-oath-vpn, make sure it's executable
 * Adjust and copy the file yubi-oath-vpn.service to $HOME/.config/systemd/user/yubi-oath-vpn.service
 
 ### Autostart via XDG autostart (KDE, Gnome, LXDE)
 
-* Copy yubi-oath-vpn binary to $HOMR/Apps/yubi-oath-vpn, make sure it's executable
+* Copy yubi-oath-vpn binary to $HOME/Apps/yubi-oath-vpn, make sure it's executable
 * Adjust and copy the file yubi-oath-vpn.desktop to $HOME/.config/autostart/yubi-oath-vpn.desktop
 
 ## Limitations


### PR DESCRIPTION
Change "$HOMR" to "$HOME"