### PR TITLE
:ambulance: Continue after error that appears when using a Yubikey 5

### DIFF
--- a/yubikey/scard/scard_yubikey.go
+++ b/yubikey/scard/scard_yubikey.go
@@ -63,13 +63,12 @@ func (key *scardYubiKey) GetCodeWithPassword(pwd string) (string, error) {
 
 	rsp, err := key.selectAid(AID_OTP)
 	if err != nil {
-		return "", err
+		fmt.Printf("Error setting 'AID_OTP': %s\n", err)
 	}
 
 	serial, err := key.readSerial()
 	if err != nil {
-		fmt.Println("Error Transmit:", err)
-		return "", err
+		fmt.Printf("Error reading serial: %s\n", err)
 	}
 	fmt.Printf("% 0x \n", rsp)
 	fmt.Printf("serial %d\n", serial)


### PR DESCRIPTION
Trying to read the Yubikey's serial fails for the Yubikey 5. But since we don't use the serial anywhere, this is not critical or harmful and we can continue as if nothing happened. This makes it work with the Yubikey 5.