### PR TITLE
Add support for multiple slots

### DIFF
--- a/cmd/yubi-oath-vpn/options_linux.go
+++ b/cmd/yubi-oath-vpn/options_linux.go
@@ -2,5 +2,6 @@ package main
 
 type Options struct {
 	ConnectionName string `required:"yes" short:"c" long:"connection" description:"The name of the connection as shown by 'nmcli c show'"`
+	SlotName       string `required:"no" short:"s" long:"slot" description:"The name of the YubiKey slot to use (typically of the form user@example.com)"`
 	ShowVersion    bool   `required:"no" short:"v" long:"version" description:"Show version and exit"`
 }

--- a/cmd/yubi-oath-vpn/options_windows.go
+++ b/cmd/yubi-oath-vpn/options_windows.go
@@ -2,5 +2,6 @@ package main
 
 type Options struct {
 	ConnectionName string `required:"yes" short:"c" long:"connection" description:"The name of the OpenVPN connection without extension'"`
+	SlotName       string `required:"no" short:"s" long:"slot" description:"The name of the YubiKey slot to use (typically of the form user@example.com)"`
 	ShowVersion    bool   `required:"no" short:"v" long:"version" description:"Show version and exit"`
 }

--- a/cmd/yubi-oath-vpn/yubi-oath-vpn.go
+++ b/cmd/yubi-oath-vpn/yubi-oath-vpn.go
@@ -86,7 +86,7 @@ func main() {
 			if applicableYubiKey(key) {
 				connectedToTun, _ := isConnectedToTun()
 				if !connectedToTun {
-					controller.ConnectWith(key, opts.ConnectionName)
+					controller.ConnectWith(key, opts.ConnectionName, opts.SlotName)
 				} else {
 					log.Printf("Connected TUN device found, not trying to connect")
 				}

--- a/gui2/gui_controller.go
+++ b/gui2/gui_controller.go
@@ -18,7 +18,7 @@ type ConnectionParameters struct {
 }
 
 type GuiController interface {
-	ConnectWith(key yubikey.YubiKey, connectionId string)
+	ConnectWith(key yubikey.YubiKey, connectionId string, slotName string)
 	InitializeConnection() chan ConnectionParameters
 	ConnectionResult(events netctrl.ConnectionAttemptResult)
 	SetLatestVersion(release githubreleasemon.Release)
@@ -33,6 +33,7 @@ type guiController struct {
 	yubiKey                  yubikey.YubiKey
 	initializeConnectionChan chan ConnectionParameters
 	connectionId             string
+	slotName                 string
 	cancelCurrentConnection  context.CancelFunc
 }
 
@@ -102,9 +103,9 @@ func GuiControllerNew(ctx context.Context, title string) (GuiController, error) 
 	return controller, nil
 }
 
-func (ctrl *guiController) ConnectWith(key yubikey.YubiKey, connectionId string) {
+func (ctrl *guiController) ConnectWith(key yubikey.YubiKey, connectionId string, slotName string) {
 	println("ConnectWith")
-	ctrl.sendEvent(evKeyInserted, key, connectionId)
+	ctrl.sendEvent(evKeyInserted, key, connectionId, slotName)
 	go func() {
 		<-key.Context().Done()
 

--- a/gui2/states.go
+++ b/gui2/states.go
@@ -88,6 +88,7 @@ func eventString(e *fsm.Event, idx int) string {
 func (ctrl *guiController) enterPrepare(e *fsm.Event) {
 	key := key(e, 0)
 	connectionId := eventString(e, 1)
+	slotName := eventString(e, 2)
 	//key.RequiresPassword()
 	// TODO password required?
 	glib.IdleAdd(func() {
@@ -96,6 +97,7 @@ func (ctrl *guiController) enterPrepare(e *fsm.Event) {
 
 	ctrl.yubiKey = key
 	ctrl.connectionId = connectionId
+	ctrl.slotName = slotName
 	ctrl.sendEvent(evPasswordRequired, key, connectionId)
 }
 func (ctrl *guiController) leavePrepare(e *fsm.Event) {
@@ -139,7 +141,7 @@ func (ctrl *guiController) enterConnecting(e *fsm.Event) {
 	ctrl.gtkGui.HideError()
 
 	password := e.Args[0].(string)
-	code, err := ctrl.yubiKey.GetCodeWithPassword(password)
+	code, err := ctrl.yubiKey.GetCodeWithPassword(password, ctrl.slotName)
 
 	println("code", code)
 	println("err", err)

--- a/yubierror/errors.go
+++ b/yubierror/errors.go
@@ -7,6 +7,7 @@ const (
 	ErrorChkWrong      YubiKeyError = iota
 	ErrorWrongPassword YubiKeyError = iota
 	ErrorUserCancled   YubiKeyError = iota
+	ErrorSlotNotFound  YubiKeyError = iota
 )
 
 func (e YubiKeyError) Error() string {
@@ -17,6 +18,8 @@ func (e YubiKeyError) Error() string {
 		return "Wrong YubiKey password"
 	case ErrorUserCancled:
 		return "User canceled"
+	case ErrorSlotNotFound:
+		return "No slot with the specified name was found"
 	}
 	return "unknown error"
 }

--- a/yubikey/yubikey.go
+++ b/yubikey/yubikey.go
@@ -4,5 +4,5 @@ import "context"
 
 type YubiKey interface {
 	Context() context.Context
-	GetCodeWithPassword(password string) (string, error)
+	GetCodeWithPassword(password string, slotName string) (string, error)
 }


### PR DESCRIPTION
Rewrite TLV handling to return a list instead of map. This way,
the name tags can be inspected and the correct one can be picked.

The desired slot name is passed as an (optional) argument. If the
argument is omitted, the first slot is used.

Fixes #11 