### PR TITLE
Bugfixes for many slots in use & no integrated scard readers

### DIFF
--- a/scardmonitor/scardmonitor.go
+++ b/scardmonitor/scardmonitor.go
@@ -184,7 +184,7 @@ func (mon *scardMon) updateLoop() {
 			var err error
 			log.Info().Msg("Listing scard readers")
 			readers, err = ctx.ListReaders()
-			if err != nil {
+			if err != nil && err != scard.ErrNoReadersAvailable {
 				log.Error().Err(err).Msg("Could not list scard readers, assuming broken context")
 				contextBroken = true
 				time.Sleep(100 * time.Millisecond)

--- a/yubikey/scard/scard_yubikey.go
+++ b/yubikey/scard/scard_yubikey.go
@@ -170,7 +170,12 @@ func (key *scardYubiKey) GetCodeWithPassword(pwd string, slotName string) (strin
 		panic("Verification failed")
 	}
 
-	var cmd_5 = []byte{0x00, byte(CALCULATE_ALL), 0x00, 0x01, 0x0A, 0x74, 0x08}
+	var cmd_5 = []byte{
+		0x00, byte(CALCULATE_ALL), 0x00, 0x01,
+		0x00,       // This makes it an extended-length APDU
+		0x00, 0x0A, // Payload size 0x000A
+		0x74, 0x08, // There's going to be a time value of length 8
+	}
 
 	timeBuffer := make([]byte, 8)
 


### PR DESCRIPTION
Hi Mene! After quite some time, we once again have some fixes.

* The tool stopped working for me when I added a 7th TOTP secret to my key. This is because by default, the response containing all the slots was limited to 256 bytes. Fixed by using an extended-length APDU.
* Our new Framework laptops don't have an integrated smartcard reader, thus there is none at all when nothing is connected via USB. This caused considerable log spam, because for some reason the smartcard library treats this as an error state.