### PR TITLE
Bugfixes for many slots in use & no integrated scard readers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,7 @@ jobs:
               - /tmp/docker_pushed
   build:
     docker:
-      - image: menedev/yubi-oath-vpn-builder:$CIRCLE_SHA1
-      
-    working_directory: /go/src/github.com/MeneDev/yubi-oath-vpn
+      - image: menedev/yubi-oath-vpn-builder:$CIRCLE_SHA1      
     environment:
       GITHUB_USER: MeneDev
       GITHUB_PROJECT: yubi-oath-vpn
@@ -49,12 +47,12 @@ jobs:
               - /go/.cache
 
       - run:
-          name: Build project for linux
+          name: Build project for Linux amd64
           command: |
             tag="$(semantics --output-tag --dry-run)"
-            go build -o release/yubi-oath-vpn-linux_amd64  -tags "glib_2_66" -ldflags="-s -w -X \"main.Version=${tag:-not a release}\" -X \"main.BuildDate=$(date --utc)\" -X \"main.BuildNumber=$CIRCLE_BUILD_NUM\" -X \"main.BuildCommit=$CIRCLE_SHA1\"" -v github.com/MeneDev/yubi-oath-vpn/cmd/yubi-oath-vpn
+            go build -o release/yubi-oath-vpn-linux_amd64 -tags "glib_2_66" -ldflags="-s -w -X \"main.Version=${tag:-not a release}\" -X \"main.BuildDate=$(date --utc)\" -X \"main.BuildNumber=$CIRCLE_BUILD_NUM\" -X \"main.BuildCommit=$CIRCLE_SHA1\"" -v github.com/MeneDev/yubi-oath-vpn/cmd/yubi-oath-vpn
       - run:
-          name: Build project for windows
+          name: Build project for Windows 
           command: |
             tag="$(semantics --output-tag --dry-run)"
             CGO_LDFLAGS_ALLOW='.*' CGO_CFLAGS_ALLOW='.*' CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ CGO_ENABLED=1 GOOS=windows GOARCH=amd64 PKG_CONFIG_PATH=/usr/x86_64-w64-mingw32/sys-root/mingw/lib/pkgconfig go build -o release/windows/yubi-oath-vpn-win_amd64.exe -tags "glib_2_66" -ldflags="-s -w -X \"main.Version=${tag:-not a release}\" -X \"main.BuildDate=$(date --utc)\" -X \"main.BuildNumber=$CIRCLE_BUILD_NUM\" -X \"main.BuildCommit=$CIRCLE_SHA1\"" -v github.com/MeneDev/yubi-oath-vpn/cmd/yubi-oath-vpn

--- a/builder2/Dockerfile
+++ b/builder2/Dockerfile
@@ -26,6 +26,10 @@ ENV GOPATH /go
 ENV GOCACHE /go/.cache
 ENV PATH "$PATH:$GOPATH/bin"
 
+# hack, but currently don't bother how to properly setup go in current version
+RUN mkdir /go
+RUN chmod a+rwx /go
+
 RUN go install github.com/tcnksm/ghr@v0.15.0 
 RUN go install github.com/stevenmatthewt/semantics@latest
 

--- a/scardmonitor/scardmonitor.go
+++ b/scardmonitor/scardmonitor.go
@@ -184,7 +184,7 @@ func (mon *scardMon) updateLoop() {
 			var err error
 			log.Info().Msg("Listing scard readers")
 			readers, err = ctx.ListReaders()
-			if err != nil {
+			if err != nil && err != scard.ErrNoReadersAvailable {
 				log.Error().Err(err).Msg("Could not list scard readers, assuming broken context")
 				contextBroken = true
 				time.Sleep(100 * time.Millisecond)

--- a/yubikey/scard/scard_yubikey.go
+++ b/yubikey/scard/scard_yubikey.go
@@ -170,7 +170,12 @@ func (key *scardYubiKey) GetCodeWithPassword(pwd string, slotName string) (strin
 		panic("Verification failed")
 	}
 
-	var cmd_5 = []byte{0x00, byte(CALCULATE_ALL), 0x00, 0x01, 0x0A, 0x74, 0x08}
+	var cmd_5 = []byte{
+		0x00, byte(CALCULATE_ALL), 0x00, 0x01,
+		0x00,       // This makes it an extended-length APDU
+		0x00, 0x0A, // Payload size 0x000A
+		0x74, 0x08, // There's going to be a time value of length 8
+	}
 
 	timeBuffer := make([]byte, 8)
 


### PR DESCRIPTION
This is a clone of #23 to enable building without sharing the token for docker hub.

Summary:

* The tool stopped working for me when I added a 7th TOTP secret to my key. This is because by default, the response containing all the slots was limited to 256 bytes. Fixed by using an extended-length APDU.
* Our new Framework laptops don't have an integrated smartcard reader, thus there is none at all when nothing is connected via USB. This caused considerable log spam, because for some reason the smartcard library treats this as an error state.